### PR TITLE
feat: check-page mobile layout

### DIFF
--- a/css/check.css
+++ b/css/check.css
@@ -342,8 +342,43 @@ h2 {
     padding-top: 1rem;
   }
 
+  .text-wrapper:after {
+    display: none;
+  }
+
   .speech-input-wrapper {
     gap: 0.5rem;
+    position: fixed;
+    bottom: 0;
+    background: white;
+    z-index: 1;
+    left: 0;
+    padding: 16px;
+    border-top: solid 1px #E5E5E5;
+  }
+
+  .speech-input-wrapper:before {
+    content: '';
+    position: absolute;
+    top: -51px;
+    width: 100%;
+    background: linear-gradient(to bottom, transparent, white);
+    left: 0;
+    height: 50px;
+  }
+
+  .analyse-wrapper {
+    padding-top: 32px;
+    padding-bottom: 300px;
+  }
+
+  .text {
+    overflow: initial;
+    max-height: initial;
+  }
+
+  #speech-text {
+    max-height: 100px;
   }
 
   .text-danger.label {
@@ -352,6 +387,7 @@ h2 {
     line-height: 20px;
     display: block;
   }
+
   .text-danger {
     font-size: 12px;
     line-height: 16px;


### PR DESCRIPTION
- чат закріплений внизу сторінки
- додається тінь, щоб показати, що текст можна скролити


https://github.com/DenysBielov/genocide-speech-monitor/assets/16645430/1b5353b5-3efc-4b67-875a-40dc5ef7cff6

<img width="426" alt="Screenshot 2023-11-23 at 00 48 57" src="https://github.com/DenysBielov/genocide-speech-monitor/assets/16645430/a516ef3b-9990-4add-8318-5622d8c4dc50">
<img width="409" alt="Screenshot 2023-11-23 at 00 49 32" src="https://github.com/DenysBielov/genocide-speech-monitor/assets/16645430/1c8aaace-13a1-40b3-b1e0-a29f3611c56a">
